### PR TITLE
Fixed bugs

### DIFF
--- a/arith_speed/arith_speed.cpp
+++ b/arith_speed/arith_speed.cpp
@@ -984,7 +984,7 @@ int main(int argc, char** argv) {
 	// retrieve devices to be benchmarked
 	cl_device_id *used_devices = (cl_device_id*) malloc(sizeof(cl_device_id) * num_devices);
 	unsigned int used_num_devices = 0;
-	if((devices_str == '\0') || (strcmp(devices_str, "all") == 0)) {
+	if (!devices_str or devices_str[0] == '\0' or strcmp(devices_str, "all") == 0) {
 		// nothing specified, run benchmark for all devices
 		for(unsigned int i = 0; i < num_devices; i++) used_devices[i] = devices[i];
 		used_num_devices = num_devices;
@@ -1014,7 +1014,7 @@ int main(int argc, char** argv) {
 		sizes[i] = 0;
 	}
 	unsigned int num_sizes = 0;
-	if(sizes_str == '\0') {
+	if (!sizes_str or sizes_str[0] == '\0') {
 		// nothing specified, test for maximum
 		num_sizes = 1;
 		for (unsigned int i = 0; i < used_num_devices; i++) {
@@ -1057,7 +1057,7 @@ int main(int argc, char** argv) {
 	// retrieve functions to be tested
 	unsigned int num_functions = 0;
 	_FUNCTION* functions = NULL;
-	if (function_str == NULL || function_str == '\0') {
+	if (function_str == NULL or function_str[0] == '\0') {
 		functions = (_FUNCTION*) malloc(sizeof(_FUNCTION) * MAX_FUNCTIONS);
 		functions[0] = _ADD;
 		functions[1] = _SUB;
@@ -1119,18 +1119,18 @@ int main(int argc, char** argv) {
 			ptr = strtok(NULL, ",");
 		}
 	}
-	if (local_str != NULL && local_str != '\0') {
+	if (local_str != NULL && local_str[0] != '\0') {
         localA = atoi(local_str);
         if(localA <= 0) fprintf(stderr, "Error: invalid argument for local: %s\n", local_str);
     }
-	if (blocks_str != NULL && blocks_str != '\0') {
+	if (blocks_str != NULL && blocks_str[0] != '\0') {
         blocksA = atoi(blocks_str);
         if(blocksA <= 0) fprintf(stderr, "Error: invalid argument for blocks: %s\n", blocks_str);
     }
 
 	// retrieve amount of repeats for each data-point
 	unsigned int repeats = 0;
-	if (repeat_str == '\0') {
+	if (!repeat_str or repeat_str[0] == '\0') {
 		repeats = 1;
 	} else {
 		if (sscanf(repeat_str, "%d", &repeats) > 0) {

--- a/buffer_bandwidth/buffer_bandwidth.cpp
+++ b/buffer_bandwidth/buffer_bandwidth.cpp
@@ -461,7 +461,7 @@ int main(int argc, char** argv) {
 	// retrieve devices to be benchmarked
 	cl_device_id *used_devices = (cl_device_id*) malloc(sizeof(cl_device_id) * num_devices);
 	unsigned int used_num_devices = 0;
-	if((devices_str == '\0') || (strcmp(devices_str, "all") == 0)) {
+	if(!devices_str or devices_str[0] == '\0' or strcmp(devices_str, "all") == 0) {
 		// nothing specified, run benchmark for all devices
 		for(unsigned int i = 0; i < num_devices; i++) used_devices[i] = devices[i];
 		used_num_devices = num_devices;
@@ -491,7 +491,7 @@ int main(int argc, char** argv) {
 		sizes[i] = 0;
 	}
 	unsigned int num_sizes = 0;
-	if(sizes_str == '\0') {
+	if (!sizes_str or sizes_str[0] == '\0') {
 		// nothing specified, use default
 		num_sizes = 1;
 		for (unsigned int i = 0; i < used_num_devices; i++) {
@@ -533,7 +533,7 @@ int main(int argc, char** argv) {
 	
 	// retrieve amount of repeats for each data-point
 	unsigned int repeats = 0;
-	if (repeat_str == '\0') {
+	if (!repeat_str or repeat_str[0] == '\0') {
 		repeats = DEFAULT_REPEATS;
 	} else {
 		if (sscanf(repeat_str, "%d", &repeats) > 0) {
@@ -546,7 +546,7 @@ int main(int argc, char** argv) {
 	
 	// retrieve amount of iterations used for each data-point
 	unsigned int iterations = 0;
-	if (iterations_str== '\0') {
+	if (!iterations_str or iterations_str[0] == '\0') {
 		iterations = DEFAULT_ITERATIONS;
 	} else {
 		if (sscanf(iterations_str, "%d", &iterations) > 0) {

--- a/cllib/clcommon.h
+++ b/cllib/clcommon.h
@@ -60,7 +60,7 @@ along with uCLbench.  If not, see <http://www.gnu.org/licenses/>.
 	#include <string.h>
 #endif
 
-#include "CL/cl.hpp"
+#include "CL/opencl.hpp"
 
 bool oclCheckErr(int err, const char* errorMessage);
 

--- a/mem_streaming/mem_streaming.cpp
+++ b/mem_streaming/mem_streaming.cpp
@@ -430,7 +430,7 @@ int main(int argc, char** argv) {
 	// retrieve devices to be benchmarked
 	cl_device_id *used_devices = (cl_device_id*) malloc(sizeof(cl_device_id) * num_devices);
 	unsigned int used_num_devices = 0;
-	if((devices_str == '\0') || (strcmp(devices_str, "all") == 0)) {
+	if (!devices_str or devices_str[0] == '\0' or strcmp(devices_str, "all") == 0) {
 		// nothing specified, run benchmark for all devices
 		for(unsigned int i = 0; i < num_devices; i++) used_devices[i] = devices[i];
 		used_num_devices = num_devices;
@@ -460,7 +460,7 @@ int main(int argc, char** argv) {
 		sizes[i] = 0;
 	}
 	unsigned int num_sizes = 0;
-	if(sizes_str == '\0') {
+	if (!sizes_str or sizes_str[0] == '\0') {
 		// nothing specified, test for maximum
 		num_sizes = 1;
 		for (unsigned int i = 0; i < used_num_devices; i++) {
@@ -502,7 +502,7 @@ int main(int argc, char** argv) {
 	
 	// retrieve amount of repeats for each data-point
 	unsigned int repeats = 0;
-	if (repeat_str == '\0') {
+	if (!repeat_str or repeat_str[0] == '\0') {
 		repeats = DEFAULT_REPEATS;
 	} else {
 		if (sscanf(repeat_str, "%d", &repeats) > 0) {
@@ -515,7 +515,7 @@ int main(int argc, char** argv) {
 	
 	// retrieve amount of iterations used for each data-point
 	unsigned int iterations = 0;
-	if (iterations_str== '\0') {
+	if (!iterations_str or iterations_str[0] == '\0') {
 		iterations = DEFAULT_ITERATIONS;
 	} else {
 		if (sscanf(iterations_str, "%d", &iterations) > 0) {
@@ -528,7 +528,7 @@ int main(int argc, char** argv) {
 
     int f4 = 0;
     char vec[16];
-    if (vector_str== '\0') {
+    if (vector_str[0] == '\0') {
         f4 = 0;
     } else {
         if (sscanf(vector_str, "%d", &f4) < 0 || f4 < 0 || f4 > 4) {


### PR DESCRIPTION
I fixed 2 bugs. Firstly, the latest OpenCL C++ bindings use the header opencl.hpp, not cl.hpp.

Furthermore, when parsing command line arguments, the empty-string tests are not correct. I first test if char* is NULL, then check if the first element is \0.